### PR TITLE
Expose `build` and `list_icons` to Python

### DIFF
--- a/src/amp/domain.rs
+++ b/src/amp/domain.rs
@@ -83,9 +83,9 @@ pub trait AmpIndexer {
 }
 
 /// Dictionary encoding for URLs
-pub fn extract_template(
-    url: &str,
-    template_lookup: &mut HashMap<String, u32>,
+pub fn extract_template<'a>(
+    url: &'a str,
+    template_lookup: &mut HashMap<&'a str, u32>,
     templates: &mut HashMap<u32, String>,
 ) -> (u32, String) {
     let split_idx = url.find('?').unwrap_or_else(|| url.rfind('/').unwrap_or(0));
@@ -95,10 +95,28 @@ pub fn extract_template(
         Some(&id) => (id, suffix.to_string()),
         None => {
             let id = template_lookup.len() as u32;
-            template_lookup.insert(template.to_string(), id);
+            template_lookup.insert(template, id);
             templates.insert(id, template.to_string());
             (id, suffix.to_string())
         }
+    }
+}
+
+/// A dictionary encoder that inserts a `needle` into the `haystack` (i.e. the dictionary)
+/// and the auxiliary lookup table. It returns an integer identifier from the lookup table
+/// for the `needle`.
+pub fn dictionary_encode<'a>(
+    needle: &'a str,
+    lookup_tbl: &mut HashMap<&'a str, u32>,
+    haystack: &mut HashMap<u32, String>,
+) -> u32 {
+    if let Some(&id) = lookup_tbl.get(needle) {
+        id
+    } else {
+        let id = lookup_tbl.len() as u32;
+        lookup_tbl.insert(needle, id);
+        haystack.insert(id, needle.to_owned());
+        id
     }
 }
 

--- a/src/amp/domain.rs
+++ b/src/amp/domain.rs
@@ -78,6 +78,9 @@ pub trait AmpIndexer {
 
     /// Get statistics about the index
     fn stats(&self) -> HashMap<String, usize>;
+
+    /// List the icons of the index
+    fn list_icons(&self) -> Vec<String>;
 }
 
 /// Dictionary encoding for URLs

--- a/src/amp/domain.rs
+++ b/src/amp/domain.rs
@@ -21,8 +21,7 @@ pub struct OriginalAmp {
     pub iab_category: String,
     pub click_url: String,
     pub impression_url: String,
-    #[serde(rename = "icon")]
-    pub icon_id: String,
+    pub icon: String,
 }
 
 /// Common result structure

--- a/src/amp/index.rs
+++ b/src/amp/index.rs
@@ -141,6 +141,10 @@ impl AmpIndexer for BTreeAmpIndex {
         m.insert("icons_count".into(), self.icons.len());
         m
     }
+
+    fn list_icons(&self) -> Vec<String> {
+        self.icons.values().cloned().collect::<_>()
+    }
 }
 
 impl BTreeAmpIndex {

--- a/src/amp/index.rs
+++ b/src/amp/index.rs
@@ -1,5 +1,6 @@
 use crate::amp::domain::{
-    AmpIndexer, AmpResult, FullKeyword, OriginalAmp, collapse_keywords, extract_template,
+    AmpIndexer, AmpResult, FullKeyword, OriginalAmp, collapse_keywords, dictionary_encode,
+    extract_template,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Bound::{Included, Unbounded};
@@ -31,23 +32,6 @@ pub struct BTreeAmpIndex {
     icons: HashMap<u32, String>,
 }
 
-/// A helper to insert a `needle` into the `haystack` and the lookup table
-/// and then return an integer identifier from the lookup table for the `needle`.
-fn lookup_helper(
-    needle: &str,
-    lookup_tbl: &mut HashMap<String, u32>,
-    haystack: &mut HashMap<u32, String>,
-) -> u32 {
-    if let Some(&id) = lookup_tbl.get(needle) {
-        id
-    } else {
-        let id = lookup_tbl.len() as u32;
-        lookup_tbl.insert(needle.to_owned(), id);
-        haystack.insert(id, needle.to_owned());
-        id
-    }
-}
-
 impl AmpIndexer for BTreeAmpIndex {
     fn new() -> Self {
         BTreeAmpIndex {
@@ -70,9 +54,9 @@ impl AmpIndexer for BTreeAmpIndex {
 
         for amp in amps {
             // Internal advertiser ID.
-            let adv_id = lookup_helper(&amp.advertiser, &mut adv_lookup, &mut self.advertisers);
+            let adv_id = dictionary_encode(&amp.advertiser, &mut adv_lookup, &mut self.advertisers);
             // Internal icon ID.
-            let icon_id = lookup_helper(&amp.icon, &mut icon_lookup, &mut self.icons);
+            let icon_id = dictionary_encode(&amp.icon, &mut icon_lookup, &mut self.icons);
 
             // Templatize URLs
             let (url_tid, url_suf) =

--- a/src/amp/mod.rs
+++ b/src/amp/mod.rs
@@ -162,6 +162,40 @@ impl AmpIndexManager {
         let indexes = self.indexes.read().unwrap();
         indexes.contains_key(index_name)
     }
+
+    /// List all the icons of a given index.
+    /// Args:
+    ///   - `index_name`: the index name.
+    /// Returns:
+    ///   - A vector of icon IDs.
+    /// Errors:
+    ///   - `KeyError` if the given index is missing.
+    #[pyo3(signature = (index_name, /))]
+    fn list_icons(&self, index_name: &str) -> PyResult<Vec<String>> {
+        let indexes = self.indexes.read().unwrap();
+        let index = indexes
+            .get(index_name)
+            .ok_or_else(|| PyKeyError::new_err(format!("Index '{}' not found", index_name)))?;
+
+        Ok(index.list_icons())
+    }
+
+    /// Fetch index stats for a given index.
+    /// Args:
+    ///   - `index_name`: the index name.
+    /// Returns:
+    ///   - A stats dictionary.
+    /// Errors:
+    ///   - `KeyError` if the given index is missing.
+    #[pyo3(signature = (index_name, /))]
+    fn stats(&self, index_name: &str) -> PyResult<HashMap<String, usize>> {
+        let indexes = self.indexes.read().unwrap();
+        let index = indexes
+            .get(index_name)
+            .ok_or_else(|| PyKeyError::new_err(format!("Index '{}' not found", index_name)))?;
+
+        Ok(index.stats())
+    }
 }
 
 /// Submodule for the "amp" extension.

--- a/tests/amp/test_amp.py
+++ b/tests/amp/test_amp.py
@@ -115,8 +115,8 @@ def test_build_from_invalid_value(idxmgr: AmpIndexManager, amp_data: AMP_DATA_TY
 
 def test_delete_index(idxmgr: AmpIndexManager, amp_data: AMP_DATA_TYPE) -> None:
     """Test `delete` of the index manager."""
-    idxmgr.build("us/desktop", json.dumps(amp_data))
-    idxmgr.delete("us/desktop")
+    idxmgr.build(IDX_NAME, json.dumps(amp_data))
+    idxmgr.delete(IDX_NAME)
 
     assert len(idxmgr.list()) == 0
 
@@ -125,7 +125,7 @@ def test_query_index(idxmgr: AmpIndexManager, amp_data: AMP_DATA_TYPE) -> None:
     """Test `query` of the index manager."""
     idxmgr.build(IDX_NAME, json.dumps(amp_data))
 
-    suggestions: list[PyAmpResult] = idxmgr.query("us/desktop", "a missing keyword")
+    suggestions: list[PyAmpResult] = idxmgr.query(IDX_NAME, "a missing keyword")
 
     assert len(suggestions) == 0
 
@@ -136,8 +136,27 @@ def test_query_index(idxmgr: AmpIndexManager, amp_data: AMP_DATA_TYPE) -> None:
             )
         )
         for i, keyword in enumerate(expected["keywords"]):
-            suggestions: list[PyAmpResult] = idxmgr.query("us/desktop", keyword)
+            suggestions: list[PyAmpResult] = idxmgr.query(IDX_NAME, keyword)
 
             assert len(suggestions) == 1
             assert_suggestion(expected, suggestions[0])
             assert suggestions[0].full_keyword == full_keywords[i]
+
+
+def test_list_icons(idxmgr: AmpIndexManager, amp_data: AMP_DATA_TYPE) -> None:
+    """Test `delete` of the index manager."""
+    idxmgr.build(IDX_NAME, json.dumps(amp_data))
+
+    assert set(idxmgr.list_icons(IDX_NAME)) == set(data["icon"] for data in amp_data)
+
+
+def test_stats(idxmgr: AmpIndexManager, amp_data: AMP_DATA_TYPE) -> None:
+    """Test `delete` of the index manager."""
+    idxmgr.build(IDX_NAME, json.dumps(amp_data))
+    stats = idxmgr.stats(IDX_NAME)
+
+    assert stats["keyword_index_size"] > 0
+    assert stats["suggestions_count"] == len(amp_data)
+    assert stats["advertisers_count"] == len(set(data["advertiser"] for data in amp_data))
+    assert stats["url_templates_count"] > 0
+    assert stats["icons_count"] == len(set(data["icon"] for data in amp_data))


### PR DESCRIPTION
Those two will be useful for the Merino integration.

Also noticed that the icons were stored in plain in the index, changed it (via another commit) to use a lookup table similar to what we did for `advertiser`.

r? @gruberb 