### PR TITLE
chore add serp category to test fixture

### DIFF
--- a/tests/amp/test_amp.py
+++ b/tests/amp/test_amp.py
@@ -74,6 +74,7 @@ def amp_data() -> AMP_DATA_TYPE:
             "impression_url": "https://example.com/impression_url",
             "click_url": "https://example.com/click_url",
             "score": 0.3,
+            "serp_categories": [1, 2],
         },
     ]
 


### PR DESCRIPTION
Added `serp_categories` to test fixture, to ensure that it still behaves nicely with the extra field.