### PR TITLE
chore: actions workflow update

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
           - runner: macos-14
             target: aarch64


### PR DESCRIPTION
[Macos-13 is deprecated](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) All our workflows seems to be stuck cause of it.